### PR TITLE
Check for `publish` flag

### DIFF
--- a/export_archivesspace_xml/lib/exporter.rb
+++ b/export_archivesspace_xml/lib/exporter.rb
@@ -4,6 +4,7 @@ module ExportArchivesspaceXml
     def export()
       collection_ids = []
       resources(recent: CONFIG[:export_only_recent_eads]).each do |resource|
+        next unless  resource['publish']
         id   = resource['uri'].split('/')[-1]
         puts "Starting collection #{id}."
         collection_ids << id
@@ -21,7 +22,7 @@ module ExportArchivesspaceXml
       end
       puts "Uploading index page"
       all_resources = resources(recent: nil)
-      all_collection_ids = all_resources.map { |r| r['uri'].split('/')[-1]}.to_a
+      all_collection_ids = all_resources.select {|r| r['publish'] }.map { |r| r['uri'].split('/')[-1]}.to_a
       upload_file(IndexPage.new.html(all_collection_ids), 'index.html')
     end
 
@@ -31,7 +32,7 @@ module ExportArchivesspaceXml
     end
 
     # A list of resource ids in the repository.
-    # If an integer `recent` is specisfied, then
+    # If an integer `recent` is specified, then
     # only export items modified in the past `recent` days.
     def resources(recent: nil)
       options = {include_unpublished: false, all_ids: true }

--- a/export_archivesspace_xml/lib/index_page.rb
+++ b/export_archivesspace_xml/lib/index_page.rb
@@ -2,7 +2,7 @@ module ExportArchivesspaceXml
   class IndexPage
     def html(collection_ids)
       list = collection_ids.map do |id|
-        "<li><a href =\"https://#{ENV["AWS_BUCKET"]}/#{id}.ead.xml\" >#{id}</a></li>"
+        "<li><a href =\"https://#{CONFIG[:aws_bucket]}/#{id}.ead.xml\" >#{id}</a></li>"
       end.join
 
       index = "<html xmlns=\"http://www.w3.org/1999/xhtml\" >


### PR DESCRIPTION
You can't rely on the `include_unpublished: false` flag in the `ArchivesSpace::Client` library, so check individual resources.

Also fixes a problem in the index page which caused bad URLS when running the code from a dev instance.