### PR TITLE
Use forked version of lyrasis/archivesspace-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
-gem 'archivesspace-client'
+#gem 'archivesspace-client'
+gem 'archivesspace-client', git: 'https://github.com/eddierubeiz/archivesspace-client.git', branch: 'allow_timeout_setting'
 gem 'aws-sdk'
 gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,17 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/eddierubeiz/archivesspace-client.git
+  revision: f1bf38743e51b63909a49324f528ce6b0dcdd4a1
+  branch: allow_timeout_setting
   specs:
-    archivesspace-client (0.1.11)
+    archivesspace-client (0.1.12)
       dry-cli (~> 0.7)
       httparty (~> 0.14)
       json (~> 2.0)
       nokogiri (~> 1.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     aws-eventstream (1.2.0)
     aws-partitions (1.541.0)
     aws-sdk (3.1.0)
@@ -1222,14 +1228,14 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     jmespath (1.4.0)
-    json (2.6.1)
+    json (2.6.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
-    mini_portile2 (2.6.1)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
     multi_xml (0.6.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
 
@@ -1237,9 +1243,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  archivesspace-client
+  archivesspace-client!
   aws-sdk
   byebug
 
 BUNDLED WITH
-   2.1.4
+   2.3.4


### PR DESCRIPTION
This will allow us to alter the timeout used by the client to tolerate extra-slow API responses.
Ref #23